### PR TITLE
publish package as site-imagetools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "vite-plugin-imageset",
+  "name": "vite-imagetools",
   "version": "0.0.0-development",
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "license": "MIT",
+  "homepage": "https://github.com/JonasKruckenberg/vite-imagetools",
   "files": [
     "dist"
   ],
@@ -35,6 +36,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/JonasKruckenberg/vite-plugin-imageset.git"
+    "url": "https://github.com/JonasKruckenberg/vite-imagetools.git"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import pm from "picomatch"
 import sharp from 'sharp'
 import { buildOptions, has, Options } from "./options"
 import { directives } from './directives'


### PR DESCRIPTION
This renames the package to vote-imagetools since the focus of the package has grown larger than just srcsets